### PR TITLE
chore: Use nodejs 16

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Camel K
         uses: ./
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Camel K
         uses: ./
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Camel K
         with:

--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,5 @@ inputs:
   github_token:
     description: "Optional token used when fetching the latest Camel K release to avoid hitting rate limits"
 runs:
-  using: "node12"
+  using: "node16"
   main: "main.js"


### PR DESCRIPTION
nodejs12 is deprecated in GitHub actions for quite some time